### PR TITLE
Check and fix build blocking errors for performance

### DIFF
--- a/run_cli.py
+++ b/run_cli.py
@@ -1,7 +1,7 @@
 import asyncio
 import sys
 import threading, time, models, os
-from ansio import application_keypad, mouse_input, raw_input
+from ansio import application_keypad, mouse_input
 from ansio.input import InputEvent, get_input_event
 from agent import AgentContext, UserMessage
 from python.helpers.print_style import PrintStyle
@@ -84,7 +84,7 @@ def capture_keys():
             
             if context.streaming_agent:
                 # with raw_input, application_keypad, mouse_input:
-                with input_lock, raw_input, application_keypad:
+                with input_lock, application_keypad:
                     event: InputEvent | None = get_input_event(timeout=0.1)
                     if event and (event.shortcut.isalpha() or event.shortcut.isspace()):
                         intervent=True


### PR DESCRIPTION
Remove `raw_input` import and usage from `run_cli.py` to fix build errors caused by its unavailability in the `ansio` package.

---
<a href="https://cursor.com/background-agent?bcId=bc-d15b1039-2a97-4d7a-838a-4d295ff95806">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d15b1039-2a97-4d7a-838a-4d295ff95806">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>